### PR TITLE
Add `placeDetails` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ For more details read Google [documentation](https://developers.google.com/maps/
 
 * `zoomForLocation` (Number): Zoom value when an accurate address is selected (default: 16).
 * `reverseGeocoding` (Boolean): Reverse geocoding when marker is dragged on map (default: false).
+* `placeDetails` (Boolean): If not using with a map, you can skip the `getDetails` portion to speed up the query (default: false).
 
 # Events
 

--- a/src/typeahead-addresspicker.coffee
+++ b/src/typeahead-addresspicker.coffee
@@ -46,6 +46,7 @@
         autocompleteService: {types: ["geocode"]}
         zoomForLocation: 16
         reverseGeocoding: false
+        placeDetails: true
       , options
       super(@options)
 
@@ -97,14 +98,17 @@
     # to update marker position and map center/zoom for a specific Google Map place
     updateMap: (event, place) =>
       # Send place reference to place service to get geographic information
-      @placeService.getDetails place, (response) =>
-        @lastResult = new AddressPickerResult(response)
-        if @marker
-          @marker.setPosition(response.geometry.location)
-          @marker.setVisible(true)
-        if @map
-          @mapOptions?.boundsForLocation(response)
-        $(this).trigger('addresspicker:selected', @lastResult)
+      if @placeDetails
+        @placeService.getDetails place, (response) =>
+          @lastResult = new AddressPickerResult(response)
+          if @marker
+            @marker.setPosition(response.geometry.location)
+            @marker.setVisible(true)
+          if @map
+            @mapOptions?.boundsForLocation(response)
+          $(this).trigger('addresspicker:selected', @lastResult)
+      else
+        $(this).trigger('addresspicker:selected', place)
 
     updateBoundsForPlace: (response) =>
       if response.geometry.viewport


### PR DESCRIPTION
Basically if you set `placeDetails: true`, it will skip the places `getDetails` function and send back the basic object via the event.

This defaults to `false` and the default behavior is unchanged. Only if you set this does that step get skipped.

The use-case is to make it quicker, and if not using a map. Also, this way you get the same value that is displayer, i.e. `description`, which isn't available in the details.