### PR TITLE
Bind to typeahead:autocompleted to fire when tab selected

### DIFF
--- a/spec/coffeescripts/typeahead-addresspicker.coffee
+++ b/spec/coffeescripts/typeahead-addresspicker.coffee
@@ -70,8 +70,9 @@ describe 'TypyaheadAddressPicker', ->
       @addressPicker.bindDefaultTypeaheadEvent($('#typeahead'))
 
       $('#typeahead').trigger('typeahead:selected')
+      $('#typeahead').trigger('typeahead:autocompleted')
       $('#typeahead').trigger('typeahead:cursorchanged')
-      expect(@addressPicker.updateMap.calls.count()).toEqual(2)
+      expect(@addressPicker.updateMap.calls.count()).toEqual(3)
 
   describe 'AddressPickerResult', ->
     beforeEach ->
@@ -142,4 +143,3 @@ describe 'TypyaheadAddressPicker', ->
 
     it 'should not have addressComponents', ->
       expect(@addressPickerResult.addressComponents().length).toEqual(0)
-

--- a/src/typeahead-addresspicker.coffee
+++ b/src/typeahead-addresspicker.coffee
@@ -56,9 +56,10 @@
       # Create a PlacesService on a fake DOM element
       @placeService = new google.maps.places.PlacesService(document.createElement('div'))
 
-    # Binds typeahead:selected and typeahead:cursorchanged event to @updateMap
+    # Binds typeahead trigger events to @updateMap
     bindDefaultTypeaheadEvent: (typeahead) ->
       typeahead.bind("typeahead:selected", @updateMap)
+      typeahead.bind("typeahead:autocompleted", @updateMap)
       typeahead.bind("typeahead:cursorchanged", @updateMap)
 
     # Inits google map to display selected address from autocomplete


### PR DESCRIPTION
The `typeahead:autocompleted` action was [added to twitter typeahead](https://github.com/twitter/typeahead.js/blob/588440f66559714280628a4f9799f0c4eb880a4a/CHANGELOG.md#091-april-1-2013) in version 0.9.1, which allows for events firing when chosen by tabbing through the options instead of manually clicking on them. This enables the same behavior for the address picker. 

Makes #17 a default feature.